### PR TITLE
Improve msging

### DIFF
--- a/src/System.Data.Odbc/src/Common/System/Data/Common/ExternDll.Linux.cs
+++ b/src/System.Data.Odbc/src/Common/System/Data/Common/ExternDll.Linux.cs
@@ -6,7 +6,7 @@ namespace System.Data.Common
 {
     internal static class ExternDll
     {
-        public const string Odbc32 = "odbc.so.2";
+        public const string Odbc32 = "libodbc.so.2";
     }
 }
 

--- a/src/System.Data.Odbc/src/Common/System/Data/Common/ExternDll.Osx.cs
+++ b/src/System.Data.Odbc/src/Common/System/Data/Common/ExternDll.Osx.cs
@@ -6,7 +6,7 @@ namespace System.Data.Common
 {
     internal static class ExternDll
     {
-        public const string Odbc32 = "odbc.2";
+        public const string Odbc32 = "libodbc.2";
     }
 }
 

--- a/src/System.Data.Odbc/src/Resources/Strings.resx
+++ b/src/System.Data.Odbc/src/Resources/Strings.resx
@@ -432,4 +432,7 @@
   <data name="Odbc_PlatformNotSupported" xml:space="preserve">
     <value>System.Data.ODBC is not supported on this platform.</value>
   </data>
+  <data name="Odbc_UnixOdbcNotFound" xml:space="preserve">
+    <value>Could not find dependency. Please check that unixODBC is installed.</value>
+  </data>
 </root>

--- a/src/System.Data.Odbc/src/System/Data/Odbc/OdbcConnection.cs
+++ b/src/System.Data.Odbc/src/System/Data/Odbc/OdbcConnection.cs
@@ -7,6 +7,7 @@ using System.Data.Common;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Security.Permissions;
 using System.Text;
 using SysTx = System.Transactions;
@@ -561,7 +562,14 @@ namespace System.Data.Odbc
 
         public override void Open()
         {
-            InnerConnection.OpenConnection(this, ConnectionFactory);
+            try
+            {
+                InnerConnection.OpenConnection(this, ConnectionFactory);
+            }
+            catch (DllNotFoundException e) when (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new DllNotFoundException(SR.Odbc_UnixOdbcNotFound + Environment.NewLine + e.Message);
+            }
 
             // SQLBUDT #276132 - need to manually enlist in some cases, because
             // native ODBC doesn't know about SysTx transactions.

--- a/src/System.Data.Odbc/tests/DependencyCheckTest.cs
+++ b/src/System.Data.Odbc/tests/DependencyCheckTest.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Data.Odbc.Tests
+{
+    public class DependencyCheckTest
+    {
+        [ConditionalFact(Helpers.OdbcNotAvailable)]
+        public void OdbcConnection_OpenWhenOdbcNotInstalled_ThrowsOdbcException()
+        {
+            using (var connection = new OdbcConnection(ConnectionStrings.WorkingConnection))
+            {
+                Assert.Throws<DllNotFoundException>(() => connection.Open()); 
+            }
+        }
+    }
+}

--- a/src/System.Data.Odbc/tests/Helpers.cs
+++ b/src/System.Data.Odbc/tests/Helpers.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Data.Odbc.Tests
+{
+    public static class Helpers
+    {
+        public const string OdbcIsAvailable = nameof(Helpers) + "." + nameof(CheckOdbcIsAvailable);
+        public const string OdbcNotAvailable = nameof(Helpers) + "." + nameof(CheckOdbcNotAvailable);
+
+        public static bool CheckOdbcNotAvailable() => !CheckOdbcIsAvailable();
+
+        private static bool CheckOdbcIsAvailable() => 
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 
+                PlatformDetection.IsNotWindowsNanoServer && PlatformDetection.IsNotWindowsServerCore :
+                Interop.Libdl.dlopen((
+                    RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
+                        "libodbc.2.dylib" : 
+                        "libodbc.so.2"
+                ), Interop.Libdl.RTLD_NOW) != IntPtr.Zero;
+    }
+}

--- a/src/System.Data.Odbc/tests/System.Data.Odbc.Tests.csproj
+++ b/src/System.Data.Odbc/tests/System.Data.Odbc.Tests.csproj
@@ -9,6 +9,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Windows_NT-Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="DependencyCheckTest.cs" />
+    <Compile Include="Helpers.cs" />
     <Compile Include="IntegrationTestBase.cs" />
     <Compile Include="CommandBuilderTests.cs" />
     <Compile Include="ReaderTests.cs" />
@@ -19,6 +21,12 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' != 'true'">
     <Compile Include="ConnectionStrings.Unix.cs" />
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+      <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libdl\Interop.dlopen.cs">
+      <Link>Common\Interop\Unix\libdl\Interop.dlopen.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
when not installed on linux:
```
System.Data.Odbc.OdbcException : Could not find dependency. Please check that unixOdbc is installed.
        Unable to load DLL 'odbc.so.2': The specified module or one of its dependencies could not be found.
         (Exception from HRESULT: 0x8007007E)
        Stack Trace:
           /home/maryam/git/corefx/src/System.Data.Odbc/src/System/Data/Odbc/OdbcConnection.cs(571,0): at System.Data.Odbc.OdbcConnection.Open()
           /home/maryam/git/corefx/src/System.Data.Odbc/tests/DependencyCheckTest.cs(17,0): at System.Data.Odbc.Tests.DependencyCheckTest.OdbcConnection_OpenWhenOdbcNotInstalled_ThrowsOdbcException()
```