### PR TITLE
Adding EnsureCapacity to Dictionary and adding tests

### DIFF
--- a/src/System.Collections/ref/System.Collections.cs
+++ b/src/System.Collections/ref/System.Collections.cs
@@ -78,6 +78,7 @@ namespace System.Collections.Generic
         System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
         System.Collections.Generic.IEnumerable<TKey> System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>.Keys { get { throw null; } }
         System.Collections.Generic.IEnumerable<TValue> System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>.Values { get { throw null; } }
+        public int EnsureCapacity(int capacity) { throw null; }
         bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
         object System.Collections.ICollection.SyncRoot { get { throw null; } }
         bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.netcoreapp.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.netcoreapp.cs
@@ -84,5 +84,52 @@ namespace System.Collections.Tests
         }
 
         #endregion
+
+        #region EnsureCapacity
+        
+        [Fact]
+        public void EnsureCapacity_NegativeCapacityRequested_Throws()
+        {
+            Dictionary<string, string> dictionary = new Dictionary<string, string>();
+            Assert.Throws<ArgumentOutOfRangeException>(() => dictionary.EnsureCapacity(-1));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(3)]
+        public void EnsureCapacity_DefaultCapacityOnEmptyDictionary_ReturnsCapacityRequestedLargerOrEqual(int requestedCapacity)
+        {
+            Dictionary<string, string> dictionary = new Dictionary<string, string>();
+            Assert.True(requestedCapacity <= dictionary.EnsureCapacity(requestedCapacity));
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(3)]
+        public void EnsureCapacity_CapacityRequestedSmallerThanCurrentCapacity_CapacityUnchanged(int requestedCapacity)
+        {
+            Dictionary<string, string> dictionary = new Dictionary<string, string>();
+
+            var capacity = dictionary.EnsureCapacity(requestedCapacity);
+
+            Assert.Equal(capacity, dictionary.EnsureCapacity(requestedCapacity-1));
+        }
+        
+        [Theory]
+        [InlineData(1)]
+        [InlineData(5)]
+        public void EnsureCapacity_CapacityRequestedSmallerThanCount_SetsCapacityToLargerOrEqualToExistingCount(int count)
+        {
+            Dictionary<int, int> dictionary = new Dictionary<int, int>();
+            for (int i = 0; i < count; i++)
+            {
+                dictionary.Add(i, i);
+            }
+
+            Assert.True(dictionary.Count <= dictionary.EnsureCapacity(count-1));
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Adding EnsureCapacity API to Dictionary and Adding Tests.
Implementation changes made in a coreclr PR separately.
 
TODO next:
- Next (Completes EnsureCapacity): SortedSet and HashSet - EnsureCapacity: 
(1) Read about HashSet and SortedSet implementation to plan for EnsureCapacity, 
(2) Plan and write tests

- Next (Completes TrimExcess): Dictionary, SortedSet - TrimExcess:
(1) Read implementation on other classes 
(2) Plan and write tests
  