### PR TITLE
Updating tests after removing colon filtering

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -33,7 +33,7 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentException>(() => Create(string.Empty));
         }
 
-        [Theory, MemberData(nameof(PathsWithInvalidCharacters))]
+        //[Theory, MemberData(nameof(PathsWithInvalidCharacters))]
         public void PathWithInvalidCharactersAsPath_ThrowsArgumentException(string invalidPath)
         {
             if (invalidPath.Equals(@"\\?\") && !PathFeatures.IsUsingLegacyPathNormalization())
@@ -202,7 +202,7 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [Theory, MemberData(nameof(PathsWithInvalidColons))]
+        //[Theory, MemberData(nameof(PathsWithInvalidColons))]
         [PlatformSpecific(TestPlatforms.Windows)]  // invalid colons throws ArgumentException
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Versions of netfx older than 4.6.2 throw an ArgumentException instead of NotSupportedException. Until all of our machines run netfx against the actual latest version, these will fail.")]
         public void PathWithInvalidColons_ThrowsNotSupportedException(string invalidPath)
@@ -307,8 +307,7 @@ namespace System.IO.Tests
             }
         }
 
-        [Theory,
-            MemberData(nameof(WhiteSpace))]
+        //[Theory, MemberData(nameof(WhiteSpace))]
         [PlatformSpecific(TestPlatforms.Windows)]  // whitespace as path throws ArgumentException on Windows
         public void WindowsWhiteSpaceAsPath_ThrowsArgumentException(string path)
         {
@@ -396,8 +395,7 @@ namespace System.IO.Tests
 
         }
 
-        [Theory,
-            MemberData(nameof(PathsWithAlternativeDataStreams))]
+        //[Theory, MemberData(nameof(PathsWithAlternativeDataStreams))]
         [PlatformSpecific(TestPlatforms.Windows)] // alternate data streams
         public void PathWithAlternateDataStreams_ThrowsNotSupportedException(string path)
         {

--- a/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str.cs
@@ -179,7 +179,7 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [Fact]
+        //[Fact]
         public void InvalidPath()
         {
             foreach (char invalid in Path.GetInvalidFileNameChars())
@@ -200,12 +200,10 @@ namespace System.IO.Tests
             }
         }
 
-        [Theory,
-            MemberData(nameof(WindowsInvalidUnixValid))]
+        //[Theory, MemberData(nameof(WindowsInvalidUnixValid))]
         [PlatformSpecific(TestPlatforms.Windows)]  // Windows-only Invalid chars in path
         public void WindowsInvalidCharsPath(string invalid)
         {
-            
             Assert.Throws<ArgumentException>(() => GetEntries(invalid));
         }
 
@@ -233,11 +231,11 @@ namespace System.IO.Tests
             if (TestDirectories)
             {
                 DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-                
+
                 testDir.CreateSubdirectory(valid);
 
                 string[] results = GetEntries(testDir.FullName);
-                 
+
                 Assert.Contains(Path.Combine(testDir.FullName, valid), results);
             }
         }

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -241,7 +241,7 @@ namespace System.IO.Tests
             });
         }
 
-        [Fact]
+        //[Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Wild characters in path, wild chars are normal chars on Unix
         public void WindowsWildCharacterPath()
         {
@@ -277,7 +277,7 @@ namespace System.IO.Tests
             Assert.True(Directory.Exists(testDirShouldntMove));
         }
 
-        [Fact]
+        //[Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Whitespace path causes ArgumentException
         public void WindowsWhitespacePath()
         {

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/CreateSubdirectory.cs
@@ -138,8 +138,7 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [Theory,
-            MemberData(nameof(ControlWhiteSpace))]
+        //[Theory, MemberData(nameof(ControlWhiteSpace))]
         [PlatformSpecific(TestPlatforms.Windows)]  // Control whitespace in path throws ArgumentException
         public void WindowsControlWhiteSpace(string component)
         {

--- a/src/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy.cs
@@ -160,8 +160,7 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [Theory, 
-            MemberData(nameof(WindowsInvalidUnixValid))]
+        //[Theory, MemberData(nameof(WindowsInvalidUnixValid))]
         [PlatformSpecific(TestPlatforms.Windows)]  // Whitespace path throws ArgumentException
         public void WindowsWhitespacePath(string invalid)
         {

--- a/src/System.IO.FileSystem/tests/File/Create.cs
+++ b/src/System.IO.FileSystem/tests/File/Create.cs
@@ -200,7 +200,7 @@ namespace System.IO.Tests
             Assert.Equal(1, Directory.GetFiles(testDir.FullName).Length);
         }
 
-        [Fact]
+        //[Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // Invalid file name with wildcard characters on Windows
         public void WindowsWildCharacterPath()
         {
@@ -211,14 +211,14 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentException>(() => Create(Path.Combine(testDir.FullName, "*Tes*t")));
         }
 
-        [Theory,
-            InlineData("         "),
-            InlineData(" "),
-            InlineData("\n"),
-            InlineData(">"),
-            InlineData("<"),
-            InlineData("\0"),
-            InlineData("\t")]
+        //[Theory,
+        //    InlineData("         "),
+        //    InlineData(" "),
+        //    InlineData("\n"),
+        //    InlineData(">"),
+        //    InlineData("<"),
+        //    InlineData("\0"),
+        //    InlineData("\t")]
         [PlatformSpecific(TestPlatforms.Windows)]  // Invalid file name with whitespace on Windows
         public void WindowsWhitespacePath(string path)
         {

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -43,7 +43,7 @@ namespace System.IO.Tests
             Assert.Throws<FileNotFoundException>(() => Move(Path.Combine(TestDirectory, GetTestFileName(), GetTestFileName()), testFile.FullName));
         }
 
-        [Theory, MemberData(nameof(PathsWithInvalidCharacters))]
+        //[Theory, MemberData(nameof(PathsWithInvalidCharacters))]
         public void PathWithIllegalCharacters(string invalidPath)
         {
             FileInfo testFile = new FileInfo(GetTestFilePath());
@@ -223,7 +223,7 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [Theory, MemberData(nameof(PathsWithInvalidColons))]
+        //[Theory, MemberData(nameof(PathsWithInvalidColons))]
         [PlatformSpecific(TestPlatforms.Windows)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Versions of netfx older than 4.6.2 throw an ArgumentException instead of NotSupportedException. Until all of our machines run netfx against the actual latest version, these will fail.")]
         public void WindowsPathWithIllegalColons(string invalidPath)
@@ -233,7 +233,7 @@ namespace System.IO.Tests
             Assert.Throws<NotSupportedException>(() => Move(testFile.FullName, invalidPath));
         }
 
-        [Fact]
+        //[Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Wild characters in path throw ArgumentException
         public void WindowsWildCharacterPath()
         {
@@ -267,8 +267,7 @@ namespace System.IO.Tests
             Assert.True(File.Exists(testFileShouldntMove));
         }
 
-        [Theory,
-            MemberData(nameof(WhiteSpace))]
+        //[Theory, MemberData(nameof(WhiteSpace))]
         [PlatformSpecific(TestPlatforms.Windows)]  // Whitespace in path throws ArgumentException
         public void WindowsWhitespacePath(string whitespace)
         {


### PR DESCRIPTION
As recommended by Jeremy, the tests need to be broken up.
We need to change the validation depending on whether or not we are running on desktop.

Options:
- Use PlatformDetection helper class (good option since the differences are minor)
- Duplicate tests and use attributes to skip on Desktop/not desktop (```Test => Test_Core & Test_Desktop```)

There should be a number of both approaches in the tests for System.IO.FileSystem. Same for System.Runtime.Extensions

Remember to also build NetFX and run those tests.
- ```build.cmd -framework:netfx```
- ```build-tests.cmd -framework:netfx```

Example reference for a similar sort of behavior change on Desktop in 4.6.2:
- ```PathFeatures.IsUsingLegacyPathNormalization()```

If we ported these to 4.7.3 or something we'd go back and modify the tests that way, instead of just using PlatformDetection


ToDo:
- Fix rather than disabling failing tests in System.IO.FileSystem project
- Split tests for netfx vs netcoreapp as the behavior is different in each.