### PR TITLE
Drafted fix

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
@@ -25,9 +25,6 @@ set(NATIVECRYPTO_SOURCES
     pal_x509chain.c
 )
 
-# Temporary workaround for dotnet/corefx issue #30599
-add_compile_options(-Wno-deprecated-declarations)
-
 add_library(System.Security.Cryptography.Native.Apple
     SHARED
     ${NATIVECRYPTO_SOURCES}

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509.h
@@ -42,7 +42,7 @@ Returns 1 on success, 0 on failure, any other value on invalid state.
 
 Output:
 pPublicKeyOut: Receives a CFRetain()ed SecKeyRef for the public key
-pOSStatusOut: Receives the result of SecCertificateCopyPublicKey
+pOSStatusOut: Receives the result of SecCertificateCopyKey or SecCertificateCopyPublicKey, depending on the OS version.
 */
 DLLEXPORT int32_t
 AppleCryptoNative_X509GetPublicKey(SecCertificateRef cert, SecKeyRef* pPublicKeyOut, int32_t* pOSStatusOut);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/X509Pal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/X509Pal.cs
@@ -33,6 +33,11 @@ namespace Internal.Cryptography.Pal
                         case Oids.RsaRsa:
                             return new RSAImplementation.RSASecurityTransforms(key);
                         case Oids.DsaDsa:
+                            if (key.IsInvalid) 
+                            {
+                                // SecCertificateCopyKey returns null for DSA, so fall back to manually building it.
+                                return DecodeDsaPublicKey(encodedKeyValue, encodedParameters);
+                            } 
                             return new DSAImplementation.DSASecurityTransforms(key);
                         case Oids.Ecc:
                             return new ECDsaImplementation.ECDsaSecurityTransforms(key);


### PR DESCRIPTION
cc: @janvorli, @bartonjs

Proper fix for compilation issue caused by deprecated API in macOS Mojave by

using dlsym to call available API rather than suppressing deprecation warnings.

Fixes: #30599