### PR TITLE
corefx: Using base class to share TraceListener between Debug and Trace

### DIFF
--- a/src/System.Diagnostics.TraceSource/src/System.Diagnostics.TraceSource.csproj
+++ b/src/System.Diagnostics.TraceSource/src/System.Diagnostics.TraceSource.csproj
@@ -52,16 +52,19 @@
     <Compile Include="System\Diagnostics\TraceEventCache.Unix.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Collections" />
-    <Reference Include="System.Collections.NonGeneric" />
-    <Reference Include="System.Collections.Specialized" />
-    <Reference Include="System.Diagnostics.Debug" />
-    <Reference Include="System.Diagnostics.Tools" />
-    <Reference Include="System.IO.FileSystem" />
-    <Reference Include="System.Resources.ResourceManager" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.Extensions" />
-    <Reference Include="System.Runtime.InteropServices" />
-    <Reference Include="System.Threading" />
+    <ProjectReference Include="..\..\System.Collections\src\System.Collections.csproj" />
+    <ProjectReference Include="..\..\System.Collections.NonGeneric\src\System.Collections.NonGeneric.csproj" />
+    <ProjectReference Include="..\..\System.Collections.Specialized\src\System.Collections.Specialized.csproj " />
+    <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj " />
+    <ProjectReference Include="..\..\System.Diagnostics.Tools\src\System.Diagnostics.Tools.csproj " />
+    <ProjectReference Include="..\..\System.IO.FileSystem\src\System.IO.FileSystem.csproj " />
+    <ProjectReference Include="..\..\System.Resources.ResourceManager\src\System.Resources.ResourceManager.csproj " />
+    <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
+    <ProjectReference Include="..\..\System.Runtime.Extensions\src\System.Runtime.Extensions.csproj" />
+    <ProjectReference Include="..\..\System.Runtime.InteropServices\src\System.Runtime.InteropServices.csproj" />
+    <ProjectReference Include="..\..\System.Threading\src\System.Threading.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <ReferenceFromRuntime Include="System.Private.CoreLib" />
   </ItemGroup>
 </Project>

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/DefaultTraceListener.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/DefaultTraceListener.cs
@@ -81,8 +81,24 @@ namespace System.Diagnostics
         /// </devdoc>
         public override void Fail(string message, string detailMessage)
         {
-            // UIAssert is not enabled.
+            // StackTrace stack = new StackTrace(true);
+            // string stackTrace;
+            // try
+            // {
+            //     stackTrace = stack.ToString();
+            // }
+            // catch
+            // {
+            //     stackTrace = "";
+            // }
             WriteAssert(string.Empty, message, detailMessage);
+            // if (AssertUiEnabled)
+            // {
+            //     Debug.ShowAssertDialog(stackTrace, message, detailMessage, "Assertion Failed");
+            // }
+            // else if (Debugger.IsAttached)
+            //     Debugger.Break();
+
         }
 
          private void InitializeSettings() 
@@ -104,7 +120,7 @@ namespace System.Diagnostics
             WriteLine(assertMessage);
 
             // In case the debugger is attached we break the debugger.
-            if (Debugger.IsAttached)
+            if (Debugger.IsAttached) // TODO: remove if block, and uncomment added statements above
                 Debugger.Break();
         }
 

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceInternal.cs
@@ -9,7 +9,31 @@ using System.Reflection;
 
 namespace System.Diagnostics
 {
-    internal static class TraceInternal
+    internal class TraceDebug : TraceDebugBase
+    {
+        public override bool AutoFlush { get { return TraceInternal.AutoFlush; } set { TraceInternal.AutoFlush = value; } }
+        public override void Assert(bool condition) { TraceInternal.Assert(condition); }
+        public override void Assert(bool condition, string message) { TraceInternal.Assert(condition, message); }
+        public override void Assert(bool condition, string message, string detailMessage) { TraceInternal.Assert(condition, message, detailMessage); }
+        public override void Close() { TraceInternal.Close(); }
+        public override void Fail(string message) { TraceInternal.Fail(message); }
+        public override void Fail(string message, string detailMessage) { TraceInternal.Fail(message, detailMessage); }
+        public override void Flush() { TraceInternal.Flush(); }
+        public override void Indent() { TraceInternal.Indent(); }
+        public override int IndentLevel { get { return TraceInternal.IndentLevel; } set { TraceInternal.IndentLevel = value; } }
+        public override int IndentSize { get { return TraceInternal.IndentSize; } set { TraceInternal.IndentSize = value; } }
+        public override void Unindent() { TraceInternal.Unindent(); }
+        public override void Write(object value) { TraceInternal.Write(value); }
+        public override void Write(object value, string category) { TraceInternal.Write(value, category); }
+        public override void Write(string message) { TraceInternal.Write(message); }
+        public override void Write(string message, string category) { TraceInternal.Write(message, category); }
+        public override void WriteLine(object value) { TraceInternal.WriteLine(value); }
+        public override void WriteLine(object value, string category) { TraceInternal.WriteLine(value, category); }
+        public override void WriteLine(string message) { TraceInternal.WriteLine(message); }
+        public override void WriteLine(string message, string category) { TraceInternal.WriteLine(message, category); }
+    }
+
+    internal static class TraceInternal 
     {
         private static volatile string s_appName = null;
         private static volatile TraceListenerCollection s_listeners;
@@ -43,6 +67,9 @@ namespace System.Diagnostics
                             defaultListener.IndentLevel = t_indentLevel;
                             defaultListener.IndentSize = s_indentSize;
                             s_listeners.Add(defaultListener);
+
+                            // instead of base class:
+                            // Approach2: we could set up Debug delegates here to TraceInternal implementation
                         }
                     }
                 }


### PR DESCRIPTION
I completed @noahfalk prototype (introduced [here](https://github.com/dotnet/corefx/issues/3708#issuecomment-412248598)).
I do however get a StackOverflowException when I uncomment the reflection code in Debug.cs to get type from System.Debug.TraceSource

coreclr changes here: https://github.com/maryamariyan/coreclr/pull/7/files