### PR TITLE
Expose ArgIterator

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -48,6 +48,7 @@ namespace System
         public static bool IsArmProcess { get { throw null; } }
         public static bool IsArm64Process { get { throw null; } }
         public static bool IsAlpine { get { throw null; } }
+        public static bool IsArgIteratorSupported { get { throw null; } }
         public static bool IsCentos6 { get { throw null; } }
         public static bool IsDebian { get { throw null; } }
         public static bool IsDebian8 { get { throw null; } }
@@ -66,6 +67,7 @@ namespace System
         public static bool IsNetNative { get { throw null; } }
         public static bool IsNonZeroLowerBoundArraySupported { get { throw null; } }
         public static bool IsNotIntMaxValueArrayIndexSupported { get { throw null; } }
+        public static bool IsNotArgIteratorSupported { get { throw null; } }
         public static bool IsNotArmProcess { get { throw null; } }
         public static bool IsNotArm64Process { get { throw null; } }
         public static bool IsNotFedoraOrRedHatFamily { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
@@ -37,6 +37,8 @@ namespace System
         public static bool IsNotArmProcess => !IsArmProcess;
         public static bool IsArm64Process => RuntimeInformation.ProcessArchitecture == Architecture.Arm64;
         public static bool IsNotArm64Process => !IsArm64Process;
+        public static bool IsArgIteratorSupported => IsWindows && (IsNotArmProcess || IsArm64Process);
+        public static bool IsNotArgIteratorSupported => !IsArgIteratorSupported;
 
         public static bool IsNotInAppContainer => !IsInAppContainer;
         public static bool IsWinRTSupported => IsWindows && !IsWindows7;

--- a/src/SharedFrameworkValidation/ApiCompatBaseline.LKGRuntime.CurrentRuntime.txt
+++ b/src/SharedFrameworkValidation/ApiCompatBaseline.LKGRuntime.CurrentRuntime.txt
@@ -32,7 +32,6 @@ MembersMustExist : Member 'System.Activator.CreateInstanceFrom(System.String, Sy
 MembersMustExist : Member 'System.Activator.CreateInstanceFrom(System.String, System.String, System.Object[])' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.AppDomainManager' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.AppDomainSetup' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.ArgIterator' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.Split(System.Char)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.Split(System.String)' does not exist in the implementation but it does exist in the contract.
 CannotMakeTypeAbstract : Type 'System.Diagnostics.Debugger' is abstract in the implementation but is not abstract in the contract.

--- a/src/SharedFrameworkValidation/ApiCompatBaseline.LKGSharedFramework.CurrentSharedFramework.txt
+++ b/src/SharedFrameworkValidation/ApiCompatBaseline.LKGSharedFramework.CurrentSharedFramework.txt
@@ -158,7 +158,6 @@ MembersMustExist : Member 'System.Activator.CreateInstanceFrom(System.String, Sy
 MembersMustExist : Member 'System.Activator.CreateInstanceFrom(System.String, System.String, System.Object[])' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.AppDomainManager' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.AppDomainSetup' does not exist in the implementation but it does exist in the contract.
-TypesMustExist : Type 'System.ArgIterator' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.Split(System.Char)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.Split(System.String)' does not exist in the implementation but it does exist in the contract.
 CannotMakeTypeAbstract : Type 'System.Diagnostics.Debugger' is abstract in the implementation but is not abstract in the contract.

--- a/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.cs
@@ -105,17 +105,13 @@ namespace System.Runtime.Serialization.Formatters.Tests
         {
             yield return new object[] { typeof(TypedReference) };
 
-            // These types are stubs on .NET Native and thus not byref-like
-            if (!PlatformDetection.IsNetNative)
-            {
-                yield return new object[] { typeof(RuntimeArgumentHandle) };
+            yield return new object[] { typeof(RuntimeArgumentHandle) };
 
-                // .NET Standard 2.0 doesn't have ArgIterator, but .NET Core 2.0 does
-                Type argIterator = typeof(object).Assembly.GetType("System.ArgIterator");
-                if (argIterator != null)
-                {
-                    yield return new object[] { argIterator };
-                }
+            // .NET Standard 2.0 doesn't have ArgIterator, but .NET Core 2.0 does
+            Type argIterator = typeof(object).Assembly.GetType("System.ArgIterator");
+            if (argIterator != null)
+            {
+                yield return new object[] { argIterator };
             }
         }
 

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -114,6 +114,23 @@ namespace System
         public ApplicationException(string message) { }
         public ApplicationException(string message, System.Exception innerException) { }
     }
+    public ref partial struct ArgIterator
+    {
+        private int _dummyPrimitive;
+        public ArgIterator(System.RuntimeArgumentHandle arglist) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public unsafe ArgIterator(System.RuntimeArgumentHandle arglist, void* ptr) { throw null; }
+        public void End() { }
+        public override bool Equals(object o) { throw null; }
+        public override int GetHashCode() { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public System.TypedReference GetNextArg() { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public System.TypedReference GetNextArg(System.RuntimeTypeHandle rth) { throw null; }
+        public System.RuntimeTypeHandle GetNextArgType() { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)]
+        public int GetRemainingCount() { throw null; }
+    }
     public partial class ArgumentException : System.SystemException
     {
         public ArgumentException() { }

--- a/src/System.Runtime/src/ApiCompatBaseline.netcoreappaot.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.netcoreappaot.txt
@@ -3,3 +3,4 @@ MembersMustExist : Member 'System.String System.Runtime.CompilerServices.Runtime
 TypeCannotChangeClassification : Type 'System.DateTimeOffset' is marked as readonly in the contract so it must also be marked readonly in the implementation.
 TypeCannotChangeClassification : Type 'System.TimeSpan' is marked as readonly in the contract so it must also be marked readonly in the implementation.
 TypeCannotChangeClassification : Type 'System.Runtime.Serialization.SerializationEntry' is marked as readonly in the contract so it must also be marked readonly in the implementation.
+TypesMustExist : Type 'System.ArgIterator' does not exist in the implementation but it does exist in the contract.

--- a/src/System.Runtime/src/ApiCompatBaseline.uapaot.txt
+++ b/src/System.Runtime/src/ApiCompatBaseline.uapaot.txt
@@ -1,0 +1,1 @@
+TypesMustExist : Type 'System.ArgIterator' does not exist in the implementation but it does exist in the contract.

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -255,6 +255,7 @@
     <Compile Include="System\Text\StringBuilderTests.netcoreapp.cs" />
     <Compile Include="System\Type\TypePropertyTests.netcoreapp.cs" />
     <Compile Include="System\Type\TypeTests.netcoreapp.cs" />
+    <Compile Include="System\ArgIteratorTests.netcoreapp.cs" />
     <Compile Include="System\DoubleTests.netcoreapp.cs" />
     <Compile Include="System\SingleTests.netcoreapp.cs" />
   </ItemGroup>

--- a/src/System.Runtime/tests/System/ArgIteratorTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ArgIteratorTests.netcoreapp.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Reflection;
+using Xunit;
+
+namespace System.Tests
+{
+    public static class ArgIteratorTests
+    {
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArgIteratorSupported))]
+        public unsafe static void ArgIterator_Throws_PlatformNotSupportedException()
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => new ArgIterator(new RuntimeArgumentHandle()));
+            Assert.Throws<PlatformNotSupportedException>(() => {
+                fixed (void* p = "test")
+                {
+                    new ArgIterator(new RuntimeArgumentHandle(), p);
+                }
+            });
+            Assert.Throws<PlatformNotSupportedException>(() => new ArgIterator().End());
+            Assert.Throws<PlatformNotSupportedException>(() => new ArgIterator().Equals(new object()));
+            Assert.Throws<PlatformNotSupportedException>(() => new ArgIterator().GetHashCode());
+            Assert.Throws<PlatformNotSupportedException>(() => new ArgIterator().GetNextArg());
+            Assert.Throws<PlatformNotSupportedException>(() => new ArgIterator().GetNextArg(new RuntimeTypeHandle()));
+            Assert.Throws<PlatformNotSupportedException>(() => new ArgIterator().GetNextArgType());
+            Assert.Throws<PlatformNotSupportedException>(() => new ArgIterator().GetRemainingCount());
+        }
+    }
+}

--- a/src/System.Runtime/tests/System/Type/TypeTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Type/TypeTests.netcoreapp.cs
@@ -220,6 +220,7 @@ namespace System.Tests
 
                 yield return new object[] { typeof(TypedReference), true };
                 yield return new object[] { typeof(RuntimeArgumentHandle), true };
+                yield return new object[] { typeof(ArgIterator), true };
                 yield return new object[] { typeof(Span<>), true };
                 yield return new object[] { typeof(Span<int>), true };
                 yield return new object[] { typeof(Span<>).MakeGenericType(theT), true };

--- a/src/shims/ApiCompatBaseline.netcoreapp.netfx461.ignore.txt
+++ b/src/shims/ApiCompatBaseline.netcoreapp.netfx461.ignore.txt
@@ -2705,8 +2705,6 @@ TypesMustExist : Type 'System.ServiceProcess.ServiceInstaller' does not exist in
 TypesMustExist : Type 'System.ServiceProcess.ServiceProcessDescriptionAttribute' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.ServiceProcess.ServiceProcessInstaller' does not exist in the implementation but it does exist in the contract.
 
-// Not bringing back argiterator
-TypesMustExist : Type 'System.ArgIterator' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Console.Write(System.String, System.Object, System.Object, System.Object, System.Object, __arglist)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Console.WriteLine(System.String, System.Object, System.Object, System.Object, System.Object, __arglist)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.String.Concat(System.Object, System.Object, System.Object, System.Object, __arglist)' does not exist in the implementation but it does exist in the contract.


### PR DESCRIPTION
```
FormatterServicesTests.cs(112,52): error CS0246: The type or namespace name 'ArgIterator' could not be found (are you missing a using directive or an assembly reference?) [C:\C
odeHub\corefx\src\System.Runtime.Serialization.Formatters\tests\System.Runtime.Serialization.Formatters.Tests.csproj]
```

I won't get error if I use the ArgIterator type in System.Runtime.Tests

